### PR TITLE
Remove package.json from the example mod in favor of ccmod.json

### DIFF
--- a/example/ccmod.json
+++ b/example/ccmod.json
@@ -1,0 +1,16 @@
+{
+    "id": "my-mod",
+    "version": "1.0.0",
+    "title": "My Mod",
+    "description": "Example mod",
+    "repository": "https://github.com/CCDirectLink/CrossCode-Modding-Tutorial",
+    "tags": ["fun"],
+    "authors": ["my_nick"],
+    "icons": {
+        "24": "icon/icon.png"
+    },
+    "dependencies": {
+        "crosscode": ">=1.4.0"
+    },
+    "plugin": "plugin.js"
+}

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,0 @@
-{
-    "name": "my-mod",
-    "ccmodHumanName": "My Mod",
-    "version": "1.0.0",
-    "plugin": "plugin.js"
-}


### PR DESCRIPTION
I noticed that this example mod is referenced on the modding tutorial: https://wiki.c2dl.info/CrossCode_Modding_Tutorial#cite_ref-1

